### PR TITLE
fix #653 on branch 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - [了解华炎魔方](https://www.steedos.com/platform/?from=github)
 - [如何使用华炎魔方，快速开发随需定制的管理系统？](https://www.steedos.com/developer/)
-- [基于华炎魔方开发的OA系统实例](https://github.com/steedos/steedos-project-oa)
+- [基于华炎魔方开发的OA系统实例](https://github.com/steedos/steedos-project-saas)
 - [基于华炎魔方开发的合同管理系统实例](https://github.com/steedos/steedos-contracts-app)
 
 # 数据建模

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - [了解华炎魔方](https://www.steedos.com/platform/?from=github)
 - [如何使用华炎魔方，快速开发随需定制的管理系统？](https://www.steedos.com/developer/)
-- [基于华炎魔方开发的OA系统实例](https://github.com/steedos/steedos-project-saas)
+- [基于华炎魔方开发的OA系统实例](https://github.com/steedos/steedos-project-oa)
 - [基于华炎魔方开发的合同管理系统实例](https://github.com/steedos/steedos-contracts-app)
 
 # 数据建模

--- a/packages/standard-objects/object-database/datasources.object.js
+++ b/packages/standard-objects/object-database/datasources.object.js
@@ -20,7 +20,7 @@ Creator.Objects['datasources'].methods = {
         var userSession = req.user
             var recordId = req.params._id;
             var spaceId = userSession.spaceId
-            let doc = await objectql.getObject('datasources').findOne(recordId, {filters: `(space eq ${spaceId})`});
+            let doc = await objectql.getObject('datasources').findOne(recordId, {filters: `(space eq \'${spaceId}\')`});
             if(doc){
                 var datasource;
                 try {

--- a/packages/standard-objects/object-database/datasources.zh-CN.i18n.yml
+++ b/packages/standard-objects/object-database/datasources.zh-CN.i18n.yml
@@ -24,7 +24,7 @@ datasources_field_mssql_options: 连接选项
 datasources_group_other_connection_options: 其他连接选项 (请注意，其他连接选项将覆盖从URL设置的参数)
 datasources_group_mssql: Mssql
 datasources_listview_all: 所有
-datasources_action_testConnection: 测试链接
+datasources_action_testConnection: 测试连接
 datasources_field_name_inlineHelpText: $t(datasources__error_name_invalid_format)
 datasources__error_name_invalid_format: $t(datasources_field_name)只能包含小写字母、数字，必须以字母开头，不能以下划线字符结尾或包含两个连续的下划线字符
 _datasources_testConnection_ok: 连接成功


### PR DESCRIPTION
fix #653 

排查后发现是odata string 格式错误，字符串数值两侧未放置单引号(\')。
同时修正了按钮上的错别字。

- fix: 外部数据源测试连接失败
- fix: “测试链接”修正为“测试连接”