### PR TITLE
修复分号导致不应存在意外执行代码 issue #1672

### DIFF
--- a/packages/core/src/init/core.ts
+++ b/packages/core/src/init/core.ts
@@ -54,9 +54,9 @@ export const initCreator = async () => {
                 const objectConfig = obj.metadata;
                 const localObjectConfig = objectql.getObjectConfig(objectConfig.name);
                 if(localObjectConfig){
-                    objectConfig.listeners = localObjectConfig.listeners; 
-                    objectConfig.methods = localObjectConfig.methods; 
-                    objectConfig.triggers = localObjectConfig.triggers; 
+                    objectConfig.listeners = localObjectConfig.listeners;
+                    objectConfig.methods = localObjectConfig.methods;
+                    objectConfig.triggers = localObjectConfig.triggers;
                     extend(objectConfig, {triggers: localObjectConfig._baseTriggers})
                 }
                 Creator.Objects[objectConfig.name] = objectConfig;
@@ -99,10 +99,11 @@ export const initCreator = async () => {
 
             let clientScripts = objectql.getClientScripts();
             _.each(clientScripts, function (scriptFile) {
-                
+
                 let code = fs.readFileSync(scriptFile, 'utf8');
 
-                clientCodes = clientCodes + '\r\n' + code
+				clientCodes = clientCodes + '\r\n;' + code + '\r\n;'
+
             });
             WebAppInternals.additionalStaticJs["/steedos_dynamic_scripts.js"] = clientCodes
 
@@ -118,7 +119,7 @@ export const initCreator = async () => {
             console.error(error)
         }
     }).promise();
-    
+
 }
 
 const getClientBaseObject = () => {
@@ -209,7 +210,7 @@ export class Core {
         app.use(bootStrapExpress);
         app.use(steedosProcess.processExpress)
         app.use(coreExpress);
-        
+
         let routers = objectql.getRouterConfigs()
         _.each(routers, (item)=>{
             app.use(item.prefix, item.router)


### PR DESCRIPTION

修复问题 #1672 

`在合并.client.js文件时，自动给文件结尾加一个分号; 防止函数被自动运行 #1672`