### PR TITLE
fix issue for auto-number generated 'undefined' due to fail to find c…

### DIFF
--- a/packages/standard-objects/base.autonumber.trigger.js
+++ b/packages/standard-objects/base.autonumber.trigger.js
@@ -90,6 +90,7 @@ const caculateAutonumber = async function (objectName, fieldName, rule, spaceId)
                 object_name: objectName,
                 field_name: fieldName,
                 space: spaceId,
+                current_no: 1,
                 rule: rule,
             };
             if (date_from && date_to) {


### PR DESCRIPTION
问题描述：
1. 版本v2.2.25
2. 新建一个对象A，并添加一个类型为“自动编号”字段，设置公式如：MG-{YYYY}-{MM}-{00000}
3. 通过列表视图在对象A中新增一行数据，自动编号字段的序号没有替换成功，出现如下错误：
4. 
<img width="408" alt="Screen Shot 2022-05-04 at 11 50 28" src="https://user-images.githubusercontent.com/5885946/166704498-7b282a4c-678e-4ce6-91e1-6463ec157bd9.png">
5. 再次新增一行数据，编号成功。


代码修改：
自动编号的触发器中，写入数据表中，缺少current_no的定义。