### PR TITLE
Update sqlserver.ts

### DIFF
--- a/packages/objectql/src/driver/sqlserver.ts
+++ b/packages/objectql/src/driver/sqlserver.ts
@@ -33,6 +33,14 @@ export class SteedosSqlServerDriver extends SteedosTypeormDriver {
     }
 
     getConnectionOptions(): ConnectionOptions {
+        if(this.config.options){
+            this.config.options.encrypt = false;
+        }
+        else{
+            this.config.options={
+                encrypt: false,
+            }
+        }
         return  {
             type: "mssql",
             url: this._url,


### PR DESCRIPTION
修复无法连接外部数据源-Sqlserver数据库的问题。
经测试，连接Sqlserver2012和Sqlserver2019均提示连接错误，错误信息为TLS/SSL或证书问题。修改连接配置属性可解决此问题。