### PR TITLE
fix: custom isCurrentUrl with prefix matching and resolvePathTemplate for menu highlight

### DIFF
--- a/builder6/webapp/src/components/AmisRender.tsx
+++ b/builder6/webapp/src/components/AmisRender.tsx
@@ -6,7 +6,7 @@
  * @Description: 
  */
 import { Builder, builder, BuilderComponent } from '@builder6/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 const normalizeLink = (to, location = window.location) => {
   to = to || "";
@@ -49,6 +49,7 @@ const normalizeLink = (to, location = window.location) => {
 export const AmisRender = function ({schema = {}, data = {}, env = {}}) {
   // console.log(`AmisRender`, schema, data, env)
   const navigate = useNavigate(); 
+  const location = useLocation();
 
   if(!(window as any).goBack){
     (window as any).goBack = ()=>{
@@ -73,10 +74,48 @@ export const AmisRender = function ({schema = {}, data = {}, env = {}}) {
       user: Builder.settings.context.user, 
       now: new Date(),
     },
+    _pathname: location.pathname,
     ...data,
   }
   const mergedEnv = {
     ...env,
+    isCurrentUrl: (to: string, ctx?: any) => {
+      if (!to) {
+        return false;
+      }
+      const link = normalizeLink(to);
+      const pathname = window.location.pathname;
+      const search = '';
+      const idx = link.indexOf('?');
+      let linkPathname = link;
+      let linkSearch = '';
+      if (~idx) {
+        linkPathname = link.substring(0, idx);
+        linkSearch = link.substring(idx);
+      }
+      if (linkSearch) {
+        if (linkPathname !== pathname) {
+          return false;
+        }
+        const currentSearch = window.location.search;
+        if (!currentSearch) {
+          return false;
+        }
+        const linkParams = new URLSearchParams(linkSearch);
+        const currentParams = new URLSearchParams(currentSearch);
+        let allMatch = true;
+        linkParams.forEach((value, key) => {
+          if (currentParams.get(key) !== value) {
+            allMatch = false;
+          }
+        });
+        return allMatch;
+      }
+      const decodedPathname = decodeURI(pathname);
+      const decodedLink = decodeURI(linkPathname);
+      // 精确匹配或前缀匹配（路径段边界）
+      return decodedPathname === decodedLink || decodedPathname.startsWith(decodedLink + '/');
+    },
     jumpTo: (to: string, action: any, ctx)=>{
       if (to === "goBack") {
         return window.history.back();

--- a/builder6/webapp/src/components/AmisRender.tsx
+++ b/builder6/webapp/src/components/AmisRender.tsx
@@ -118,10 +118,36 @@ export const AmisRender = function ({schema = {}, data = {}, env = {}}) {
         return true;
       }
       // 前缀匹配（路径段边界）：仅对 object 列表页路径生效
-      // 即 /app/{appId}/{objectName} 格式（恰好3段），才允许匹配其子路径（如 /view/xxx）
-      // 避免 /app/admin/space_users/view/xxx 同时匹配 /app/admin/space_users 和自身
+      // 即 /app/{appId}/{objectName} 格式（≤3段），才允许匹配其子路径（如 /view/xxx）
       const linkSegments = decodedLink.replace(/^\//, '').split('/');
       if (linkSegments.length <= 3 && decodedPathname.startsWith(decodedLink + '/')) {
+        // 检查是否有更具体的菜单项匹配当前 URL，避免双重高亮
+        // 例如："人员"(/app/admin/space_users) 和 "个人资料"(/app/admin/space_users/view/${userId})
+        // 当 URL 为 /app/admin/space_users/view/xxx 时，只高亮"个人资料"
+        const navPaths = (window as any)._steedosNavPaths;
+        if (navPaths && navPaths.some((p: string) => {
+          let pp = p;
+          const qi = pp.indexOf('?');
+          if (qi > -1) pp = pp.substring(0, qi);
+          const hi = pp.indexOf('#');
+          if (hi > -1) pp = pp.substring(0, hi);
+          // 跳过自身
+          if (decodeURI(pp) === decodedLink) return false;
+          // 处理含模板变量的路径（如 ${context.user.spaceUserId}），取静态前缀
+          const tmplIdx = pp.indexOf('${');
+          if (tmplIdx > -1) {
+            pp = pp.substring(0, tmplIdx);
+          }
+          const decodedNavPath = decodeURI(pp);
+          // 如果存在一个更长的导航路径：
+          // 1) 它以当前 link 为前缀（说明它是当前 link 的子路径）
+          // 2) 当前 URL 也以它的静态部分为前缀（说明当前 URL 更匹配那个菜单项）
+          // 则当前 link 不应该被前缀匹配高亮
+          return decodedNavPath.startsWith(decodedLink + '/') &&
+                 decodedPathname.startsWith(decodedNavPath);
+        })) {
+          return false;
+        }
         return true;
       }
       return false;

--- a/builder6/webapp/src/components/AmisRender.tsx
+++ b/builder6/webapp/src/components/AmisRender.tsx
@@ -113,8 +113,18 @@ export const AmisRender = function ({schema = {}, data = {}, env = {}}) {
       }
       const decodedPathname = decodeURI(pathname);
       const decodedLink = decodeURI(linkPathname);
-      // 精确匹配或前缀匹配（路径段边界）
-      return decodedPathname === decodedLink || decodedPathname.startsWith(decodedLink + '/');
+      // 精确匹配
+      if (decodedPathname === decodedLink) {
+        return true;
+      }
+      // 前缀匹配（路径段边界）：仅对 object 列表页路径生效
+      // 即 /app/{appId}/{objectName} 格式（恰好3段），才允许匹配其子路径（如 /view/xxx）
+      // 避免 /app/admin/space_users/view/xxx 同时匹配 /app/admin/space_users 和自身
+      const linkSegments = decodedLink.replace(/^\//, '').split('/');
+      if (linkSegments.length <= 3 && decodedPathname.startsWith(decodedLink + '/')) {
+        return true;
+      }
+      return false;
     },
     jumpTo: (to: string, action: any, ctx)=>{
       if (to === "goBack") {

--- a/builder6/webapp/src/pages/app/id/index.tsx
+++ b/builder6/webapp/src/pages/app/id/index.tsx
@@ -7,6 +7,34 @@ export const AppView = () => {
   const { appId } = useParams();
   const navigate = useNavigate();
 
+  const resolvePathTemplate = (path?: string, data?: Record<string, any>) => {
+    if (!path || path.indexOf('${') < 0) {
+      return path || '';
+    }
+    try {
+      const currentAmis = (window as any).amisRequire?.('amis');
+      const createObject = (window as any).BuilderAmisObject?.AmisLib?.createObject;
+      if (currentAmis && createObject) {
+        const settings = (window as any).Builder?.settings || {};
+        const scope = {
+          context: settings.context,
+          global: {
+            userId: settings.context?.userId,
+            spaceId: settings.context?.tenantId,
+            user: settings.context?.user,
+          },
+        };
+        const resolved = currentAmis.evaluate(path, createObject(scope, data || {}));
+        if (typeof resolved === 'string' && resolved) {
+          return resolved;
+        }
+      }
+    } catch (error) {
+      console.warn('resolvePathTemplate failed:', error);
+    }
+    return path;
+  };
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -22,7 +50,7 @@ export const AppView = () => {
         if (data?.default_tab) {
           // If default_tab is an object with a path, use it
           if (typeof data.default_tab === 'object' && data.default_tab !== null && data.default_tab.path) {
-            navigate(data.default_tab.path);
+            navigate(resolvePathTemplate(data.default_tab.path, data.default_tab));
             return;
           }
           // If default_tab is a string, construct the path
@@ -35,7 +63,7 @@ export const AppView = () => {
         // Fallback: Check if data exists and has at least one item with a path
         if (data?.children.length > 0 && data.children[0].path) {
           const children = _.sortBy(data.children, ['index']);
-          navigate(children[0].path);
+          navigate(resolvePathTemplate(children[0].path, children[0]));
         }
       } catch (error) {
         console.error('Error fetching data:', error);

--- a/builder6/webapp/src/pages/app/index.tsx
+++ b/builder6/webapp/src/pages/app/index.tsx
@@ -12,12 +12,32 @@ const on_click_script = `
   `;
 
   const pcInitJumtoFirstAppFirstTabScript = (payload, response, api, context) => {
+    const resolvePathTemplate = (path, data) => {
+      if (!path || path.indexOf('${') < 0) {
+        return path;
+      }
+      try {
+        var currentAmis = (window as any).amisRequire && (window as any).amisRequire('amis');
+        var createObject = (window as any).BuilderAmisObject && (window as any).BuilderAmisObject.AmisLib && (window as any).BuilderAmisObject.AmisLib.createObject;
+        if (currentAmis && createObject) {
+          const resolved = currentAmis.evaluate(path, createObject(context, data || {}));
+          if (typeof resolved === 'string' && resolved) {
+            return resolved;
+          }
+        }
+      }
+      catch(ex){
+        console.warn('resolvePathTemplate failed:', ex);
+      }
+      return path;
+    }
+
     let app_items = payload;
     if(app_items && app_items.length > 0){
       let firstApp = app_items[0];
       if(firstApp && firstApp.default_tab){
         if (typeof firstApp.default_tab === 'object' && firstApp.default_tab.path) {
-          window.location.href = firstApp.default_tab.path;
+          window.location.href = resolvePathTemplate(firstApp.default_tab.path, firstApp.default_tab);
         }
         else{
           window.location.href = `/app/${firstApp.id}/${firstApp.default_tab}`;
@@ -27,7 +47,7 @@ const on_click_script = `
       if(firstApp && firstApp.children && firstApp.children.length > 0){
         let firstTab = firstApp.children[0];
         if(firstTab){
-          window.location.href = firstTab.path;
+          window.location.href = resolvePathTemplate(firstTab.path, firstTab);
         }
       }
     }


### PR DESCRIPTION
## Changes

- **AmisRender.tsx**: Custom `isCurrentUrl` with exact match → query param match → prefix match (≤3 segments) → `_steedosNavPaths` dedup. Added `useLocation()` + `_pathname` for route-change re-render.
- **app/id/index.tsx**: `resolvePathTemplate` to resolve \${context.user.xxx} template variables before `navigate()`.
- **app/index.tsx**: Same `resolvePathTemplate` in `pcInitJumtoFirstAppFirstTabScript` adaptor.

Fixes left sidebar menu highlight for: page refresh, browser back/forward, record detail pages, double-highlight prevention, and nine-grid launcher template URL resolution.

Ref: https://github.com/steedos/steedos-plugins/issues/258