### PR TITLE
feat: 支持对象树结构列表配置默认展开行为 (#8346)

### DIFF
--- a/packages/objectql/src/types/object.ts
+++ b/packages/objectql/src/types/object.ts
@@ -138,6 +138,7 @@ abstract class SteedosObjectProperties {
   enable_tree?: boolean;
   parent_field?: string;
   children_field?: string;
+  tree_expand?: string;
   enable_enhanced_lookup?: boolean;
   enable_inline_edit?: boolean;
   enable_approvals?: boolean;
@@ -212,6 +213,7 @@ const properties = [
   "enable_tree",
   "parent_field",
   "children_field",
+  "tree_expand",
   "enable_enhanced_lookup",
   "enable_workflow",
   "is_view",

--- a/packages/schemas/object/schema.json
+++ b/packages/schemas/object/schema.json
@@ -128,6 +128,11 @@
       "type": "string",
       "description": "树状结构子节点字段，默认为children"
     },
+    "tree_expand": {
+      "type": "string",
+      "enum": ["first", "all", "none"],
+      "description": "树状结构列表默认展开行为：first 默认展开第一个节点（默认值），all 默认展开全部节点，none 默认全部收起"
+    },
     "enable_approvals": {
       "type": "boolean",
       "description": "历史步骤"

--- a/services/service-core-objects/main/default/objectTranslations/objects.en/objects.en.objectTranslation.yml
+++ b/services/service-core-objects/main/default/objectTranslations/objects.en/objects.en.objectTranslation.yml
@@ -87,6 +87,10 @@ fields:
     label: Enable Tree
     help: 
     description: Enable a tree structure to display records
+  tree_expand:
+    label: Tree Default Expand
+    help: 
+    description: Default expansion behavior of the tree list. Defaults to expanding the first node; can be set to expand all nodes or collapse all.
   enable_enhanced_lookup:
     label: Enable Enhanced Lookup
     help: 

--- a/services/service-core-objects/main/default/objectTranslations/objects.en/objects.en.objectTranslation.yml
+++ b/services/service-core-objects/main/default/objectTranslations/objects.en/objects.en.objectTranslation.yml
@@ -90,6 +90,13 @@ fields:
   tree_expand:
     label: Tree Default Expand
     help: 
+    options:
+      - label: First node only
+        value: first
+      - label: Expand all
+        value: all
+      - label: Collapse all
+        value: none
     description: Default expansion behavior of the tree list. Defaults to expanding the first node; can be set to expand all nodes or collapse all.
   enable_enhanced_lookup:
     label: Enable Enhanced Lookup

--- a/services/service-core-objects/main/default/objectTranslations/objects.zh-CN/objects.zh-CN.objectTranslation.yml
+++ b/services/service-core-objects/main/default/objectTranslations/objects.zh-CN/objects.zh-CN.objectTranslation.yml
@@ -91,6 +91,10 @@ fields:
     label: 树状结构显示
     help: 
     description: 以树状格式呈现数据层级结构，方便查看记录的父子关系。
+  tree_expand:
+    label: 树列表默认展开
+    help: 
+    description: 配置开启树状结构显示后，列表加载时的默认展开行为。默认展开第一个节点；可选择默认展开全部节点或全部收起。
   enable_enhanced_lookup:
     label: 弹出窗口查找
     help: 

--- a/services/service-core-objects/main/default/objectTranslations/objects.zh-CN/objects.zh-CN.objectTranslation.yml
+++ b/services/service-core-objects/main/default/objectTranslations/objects.zh-CN/objects.zh-CN.objectTranslation.yml
@@ -94,6 +94,13 @@ fields:
   tree_expand:
     label: 树列表默认展开
     help: 
+    options:
+      - label: 仅展开首个节点
+        value: first
+      - label: 全部展开
+        value: all
+      - label: 全部收起
+        value: none
     description: 配置开启树状结构显示后，列表加载时的默认展开行为。默认展开第一个节点；可选择默认展开全部节点或全部收起。
   enable_enhanced_lookup:
     label: 弹出窗口查找

--- a/services/service-core-objects/main/default/objects/objects/objects.object.yml
+++ b/services/service-core-objects/main/default/objects/objects/objects.object.yml
@@ -235,7 +235,7 @@ fields:
         value: all
       - label: Collapse All
         value: none
-    visible_on: '{{ data.enable_tree == true }}'
+    visible_on: '{{ formData.enable_tree == true }}'
   enable_workflow:
     name: enable_workflow
     defaultValue: true

--- a/services/service-core-objects/main/default/objects/objects/objects.object.yml
+++ b/services/service-core-objects/main/default/objects/objects/objects.object.yml
@@ -220,6 +220,22 @@ fields:
     label: Enable Tree
     sort_no: 200
     type: boolean
+  tree_expand:
+    name: tree_expand
+    group: advanced
+    hidden: false
+    label: Tree Default Expand
+    sort_no: 205
+    type: select
+    defaultValue: first
+    options:
+      - label: Expand First
+        value: first
+      - label: Expand All
+        value: all
+      - label: Collapse All
+        value: none
+    visible_on: '{{ data.enable_tree == true }}'
   enable_workflow:
     name: enable_workflow
     defaultValue: true


### PR DESCRIPTION
## 概述
解决 issue #8346，为对象的树状结构列表新增 `tree_expand` 字段，支持配置列表默认展开行为：
- `first`：仅展开第一个根节点（默认值）
- `all`：默认展开全部节点
- `none`：默认全部收起

## 改动
- `services/service-core-objects/main/default/objects/objects/objects.object.yml`：新增 `tree_expand` 字段，配置 `visible_on` 仅在 `enable_tree=true` 时显示
- `packages/schemas/object/schema.json`：新增 `tree_expand` 校验，限制 enum 为 `["first","all","none"]`
- `packages/objectql/src/types/object.ts`：在 uiSchema 输出中包含 `tree_expand`
- `services/service-core-objects/main/default/objectTranslations/objects.zh-CN/objects.zh-CN.objectTranslation.yml`：中文翻译（树列表默认展开 / 仅展开首个节点 / 全部展开 / 全部收起）
- `services/service-core-objects/main/default/objectTranslations/objects.en/objects.en.objectTranslation.yml`：英文翻译（Tree Default Expand / First node only / Expand all / Collapse all）

## 验证
B1-B11 浏览器 UI 全部测试通过：
- B1/B9：未勾选 enable_tree 时 tree_expand 隐藏
- B2：3 个中文选项展示正确，默认"仅展开首个节点"
- B3：`first` 仅展开第一个根节点
- B4：`all` 全部节点展开（indent 0/1/1/2 正确）
- B5：`none` 仅显示根节点
- B6：旧对象（tree_expand=null）兼容，默认 first 行为
- B7：uiSchema API 正确返回 tree_expand
- B8：英文 i18n options 完整
- B10：schema.json enum 限制有效
- B11：编辑回显正确

Closes #8346
