### PR TITLE
fix(objectql): 修复对象 afterInsert 创建 tabs 时 company_ids 为 undefined 的崩溃

### DIFF
--- a/packages/objectql/src/types/method_base.ts
+++ b/packages/objectql/src/types/method_base.ts
@@ -73,7 +73,12 @@ export async function getMongoInsertBaseDoc(object: any, doc: Dictionary<any>, u
 
     var extras = ["spaces", "company", "organizations", "users", "space_users", "flows", "forms"];
     if (extras.indexOf(object.name) < 0 && doc.space) {
-        if(_.has(doc, "company_ids") && _.has(doc, "company_id") && doc.company_id != doc.company_ids[0]){
+        // 注意：此处必须用真值 + Array 检查，不要使用 `_.has(doc, "company_ids")`。
+        // _.has 仅判断属性是否存在，对于显式赋值为 undefined 的字段（例如其它
+        // 触发器中以 `doc.company_ids = object.companyIds` 这类 camelCase 误写
+        // 导致字段为 undefined 的场景）依然返回 true，进而触发
+        // `doc.company_ids[0]` 抛出 "Cannot read properties of undefined (reading '0')"。
+        if(doc.company_id && Array.isArray(doc.company_ids) && doc.company_ids.length && doc.company_id != doc.company_ids[0]){
             doc.company_ids = [doc.company_id];
         }
         /* company_ids/company_id默认值逻辑*/
@@ -114,7 +119,10 @@ export async function getMongoUpdateBaseDoc(object: any, doc: Dictionary<any>, u
 
     var extras = ["spaces", "company", "organizations", "users", "space_users", "flows", "forms"];
     if (extras.indexOf(object.name) < 0) {
-        if(_.has(doc, "company_ids") && _.has(doc, "company_id") && doc.company_id != doc.company_ids[0]){
+        // 注意：此处必须用真值 + Array 检查，不要使用 `_.has(doc, "company_ids")`。
+        // _.has 对显式赋值为 undefined 的字段也返回 true，会导致后续
+        // `doc.company_ids[0]` 抛出 "Cannot read properties of undefined (reading '0')"。
+        if(doc.company_id && Array.isArray(doc.company_ids) && doc.company_ids.length && doc.company_id != doc.company_ids[0]){
             doc.company_ids = [doc.company_id];
         }
         /* company_ids/company_id级联修改逻辑*/


### PR DESCRIPTION
## 问题
通过 GraphQL 或 UI 创建新对象时，afterInsert 触发器在调用 `getObject('tabs').insert(tabDoc)` 创建对应 tab 时报错：

```
TypeError: Cannot read properties of undefined (reading '0')
  at getMongoInsertBaseDoc (packages/objectql/src/types/method_base.ts:76)
  at SteedosObjectType.insert (objectql/src/types/object.ts:1572)
  at Object.afterInsert (services/standard-object-database/main/default/triggers/objects.trigger.js:49)
```

## 根因
`method_base.ts` 中 `_.has(doc, "company_ids")` 仅判断属性是否存在，对显式赋值为 `undefined` 的字段也返回 `true`。

`objects.trigger.js` 的 afterInsert 中以 camelCase 写法 `doc.company_ids = object.companyIds`（而对象上实际为 snake_case），导致 `doc.company_ids = undefined`，但 `_.has` 仍判定存在，进而 `doc.company_ids[0]` 抛错。

## 修复
将 `_.has(doc, "company_ids") && _.has(doc, "company_id")` 改为真值 + `Array.isArray` + 长度检查：
```ts
if(doc.company_id && Array.isArray(doc.company_ids) && doc.company_ids.length && doc.company_id != doc.company_ids[0]){
```
同时在两处（insert/update）添加注释说明，避免后续被改回 `_.has`。

## 验证
- 修复前：GraphQL `mutation { objects__insert(...) }` 失败
- 修复后：同一 mutation 成功返回 `{ _id, name }`，对象创建完成并自动生成对应 tab
