### PR TITLE
feat(schemas): support auto_open_filter on listview and lookup field (#8349)

### DIFF
--- a/packages/schemas/field/schema.json
+++ b/packages/schemas/field/schema.json
@@ -417,6 +417,10 @@
       "type": ["object"],
       "description": "搜索表单默认值"
     },
+    "auto_open_filter": {
+      "type": "boolean",
+      "description": "lookup 字段：弹出选择列表时是否自动展开搜索栏。默认 false。"
+    },
     "write_requires_master_read": {
       "type": "boolean",
       "description": "设置主记录上创建、编辑或删除子记录所需的最低访问级别。此字段仅适用于master_detail字段类型。true--允许具有'读取'访问权限的用户创建、编辑或删除子记录。false = 允许具有'读取/写入'访问权限的用户创建、编辑或删除子记录的权限。此设置比 true 更严格，并且是默认值。"

--- a/packages/schemas/listview/schema.json
+++ b/packages/schemas/listview/schema.json
@@ -115,6 +115,10 @@
       "type": "boolean",
       "description": "是否要求用户先设置过滤条件后才进行数据请求"
     },
+    "auto_open_filter": {
+      "type": "boolean",
+      "description": "进入列表视图时是否自动展开搜索栏。默认 false。不影响 filter_required 的强制约束；在分栏(split)模式下不生效。"
+    },
     "scrolling_mode": {
       "type": "string",
       "description": "滚动条样式",

--- a/packages/schemas/object/schema.json
+++ b/packages/schemas/object/schema.json
@@ -742,6 +742,10 @@
           "type": ["object"],
           "description": "搜索表单默认值"
         },
+        "auto_open_filter": {
+          "type": "boolean",
+          "description": "lookup 字段：弹出选择列表时是否自动展开搜索栏。默认 false。"
+        },
         "relatedList": {
           "type": "boolean",
           "description": "用于表示是否在相关表的详细页面中作为子表显示"
@@ -824,6 +828,10 @@
         "searchable_default": {
           "type": ["object"],
           "description": "搜索表单默认值"
+        },
+        "auto_open_filter": {
+          "type": "boolean",
+          "description": "进入列表视图时是否自动展开搜索栏。默认 false。不影响 filter_required 的强制约束；在分栏(split)模式下不生效。"
         },
         "sort": {
           "type": "array",


### PR DESCRIPTION
[Issue #8349](https://github.com/steedos/steedos-platform/issues/8349)

## 变更

为列表视图新增 `auto_open_filter` 配置，在 schema 中声明。同时补齐 lookup 字段已有但未声明的 `auto_open_filter`。

- `packages/schemas/listview/schema.json` — 列表视图新增 `auto_open_filter` boolean
- `packages/schemas/field/schema.json` — lookup 字段补声明 `auto_open_filter`（代码层早已支持，schema 未声明）
- `packages/schemas/object/schema.json` — 对象 yml 内嵌字段与 list_views 两处都补声明

## 行为规则

1. 默认 `false`，向后兼容。
2. 列表视图：仅当显式 `true` 时初次加载自动展开搜索栏。
3. **不影响 `filter_required`** 原有强约束。
4. **不在 split/三栏模式生效**。

## 配套 widgets PR

https://github.com/steedos/steedos-widgets/pull/new/feat/listview-auto-open-filter-8349

## 测试

通过 puppeteer-core 控制 Chrome 已验证：
- `auto_open_filter: true` 时，company 对象 all 视图初次进入搜索栏自动展开 ✅
- 去掉该配置后搜索栏保持默认收起 ✅
- `filter_required` 分支与 split 模式：代码层 `else if(autoOpenFilter && data.display !== "split")` 守卫保证不互相影响
